### PR TITLE
Fixes bad version of insanely-fast-whisper being installed on python 3.11.X

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "insanely-fast-whisper"
-version = "0.0.12"
+version = "0.0.13"
 description = "An insanely fast whisper CLI"
 authors = [
     { name = "VB", email = "reachvaibhavs10@gmail.com" },
@@ -14,7 +14,7 @@ dependencies = [
     "setuptools>=68.2.2",
     "rich>=13.7.0",
 ]
-requires-python = ">=3.8,<=3.11"
+requires-python = ">=3.8,<3.12"
 readme = "README.md"
 license = { text = "MIT" }
 


### PR DESCRIPTION
I reproduced the python 3.11 bug that was reported in the docs, where the wrong version `0.0.8` was being isntalled. It turns out the python version restrictions where set up wrong. I've isolated it down to this case:

### Example error:

```
C:\Users\admin\dev\ingest-media\tests\test_data>pip install insanely-fast-whisper==0.0.13
ERROR: Ignored the following versions that require a different python version: 0.0.10 Requires-Python <=3.11,>=3.8; 0.0.11 Requires-Python <=3.11,>=3.8; 0.0.12 Requires-Python <=3.11,>=3.8; 0.0.13 Requires-Python <=3.11,>=3.8; 0.0.9 Requires-Python <=3.11,>=3.8
ERROR: Could not find a version that satisfies the requirement insanely-fast-whisper==0.0.13 (from versions: 0.0.1, 0.0.2, 0.0.3, 0.0.4, 0.0.5b0, 0.0.5b1, 0.0.5b2, 0.0.5b3, 0.0.5, 0.0.6, 0.0.7, 0.0.8)
ERROR: No matching distribution found for insanely-fast-whisper==0.0.13

[notice] A new release of pip is available: 23.2.1 -> 23.3.2
[notice] To update, run: python.exe -m pip install --upgrade pip
```

According to the comparison rules, 3.11.0 was legal, but 3.11.1 was not. Now any 3.11.X version will match.